### PR TITLE
Ensure config is flushed and systemd is setup before nginx

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -7,8 +7,8 @@
 
 - include: web-install.yml
 
-- include: web-nginx.yml
-  when: omero_web_setup_nginx
-
 - include: web-systemd.yml
   when: omero_web_systemd_setup
+
+- include: web-nginx.yml
+  when: omero_web_setup_nginx

--- a/tasks/web-nginx.yml
+++ b/tasks/web-nginx.yml
@@ -1,6 +1,10 @@
 ---
 # setup nginx
 
+# Flush handlers to ensure configuration is reloaded
+- name: omero web | flush systemd handlers
+  meta: flush_handlers
+
 # Check whether the web configuration needs to be regenerated
 
 - name: omero web | check web timestamp


### PR DESCRIPTION
Closes https://github.com/openmicroscopy/ansible-role-omero-web/issues/17

Testing: Set an omero web prefix before installing OMERO.web with this role (don't forget to set your static prefix too if needed).

Note: Since there is no easy way to tell whether the Nginx omero-web.conf is up-to-date or not it is only regenerated on install or upgrades, it will not be regenerated for an existing server that isn't being upgraded.