### PR TITLE
Selinux playbook

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -10,5 +10,7 @@
 - include: web-nginx.yml
   when: omero_web_setup_nginx
 
+- include: web-selinux.yml
+
 - include: web-systemd.yml
   when: omero_web_systemd_setup

--- a/tasks/web-selinux.yml
+++ b/tasks/web-selinux.yml
@@ -1,0 +1,31 @@
+---
+# NOTE: The Ansible variable `ansible_selinux.status == "enabled"` should
+# autodetect SELinux, but may give a misleading result if a dependency is
+# missing: https://github.com/ansible/ansible/issues/16612
+# so use getenforce instead
+
+# Always run including in check mode
+- name: omero web | check selinux exists
+  stat:
+    path: /usr/sbin/getenforce
+  register: selinux_getenforce_st
+  check_mode: no
+
+- name: selinux | check  selinux enabled
+  become: yes
+  command: /usr/sbin/getenforce
+  register: selinux_getenforce
+  check_mode: no
+  changed_when: False
+  when: selinux_getenforce_st.stat.exists
+
+- name: omero web | set selinux variable
+  set_fact:
+    selinux_enabled: "{{ selinux_getenforce_st.stat.exists and selinux_getenforce.stdout != 'Disabled' }}"
+
+- name: selinux | check enabled
+  become: yes
+  command: /usr/sbin/restorecon -R -v {{ omero_web_basedir }}/OMERO.web
+  check_mode: no
+  when: selinux_enabled
+

--- a/tasks/web-selinux.yml
+++ b/tasks/web-selinux.yml
@@ -28,4 +28,3 @@
   command: /usr/sbin/restorecon -R -v {{ omero_web_basedir }}/OMERO.web
   check_mode: no
   when: selinux_enabled
-


### PR DESCRIPTION
Fixes #15 

Rather than forcing the command discuseed in the issue in consumer playbook, this PR adds a new playbook to be executed in the case of SELinux-hardened systems.

The logic for detecting SELinux enforcement was copied from `openmicroscopy.selinux_utils` and might be dropped with the same caveats.

Proposing this as a bugfix i.e. `2.0.2` although could equally be treated as `2.1.0`. Arguably could be tested as part of the upgrade of Dundee production systems where SELinux is enabled.