### PR TITLE
Fix Ansible version_compare change in behaviour

### DIFF
--- a/molecule/resources/playbook.yml
+++ b/molecule/resources/playbook.yml
@@ -34,6 +34,11 @@
         that: molecule_test_omero_web_version.stdout.startswith('5.3.')
       when: not molecule_test_omero_web_installed_1.stat.exists
 
+  vars:
+    ice_python_wheel: "https://github.com/ome/zeroc-ice-py-centos7/releases/\
+      download/0.1.0/zeroc_ice-3.6.4-cp27-cp27mu-linux_x86_64.whl"
+
+
 # Attempt to upgrade
 # omero_web_release is defined in molecule.yml host_vars so:
 # - omero-web: latest: upgraded
@@ -45,3 +50,7 @@
       omero_web_config_set:
         omero.web.server_list:
           - [localhost, 12345, molecule-test]
+
+  vars:
+    ice_python_wheel: "https://github.com/ome/zeroc-ice-py-centos7/releases/\
+      download/0.1.0/zeroc_ice-3.6.4-cp27-cp27mu-linux_x86_64.whl"

--- a/tasks/web-install.yml
+++ b/tasks/web-install.yml
@@ -52,13 +52,18 @@
 
 - name: omero web | checkupgrade
   set_fact:
-    # Experimentation shows "5.3.2 | version_compare('latest', '<')" is False
-    # so this should work as expected
+    # If _omero_web_new_version does not begin with a number assume it's a
+    # custom build, always upgrade
     _omero_web_update_needed: "{{
-      omero_web_symlink_st.stat.exists and
-      (omero_web_version.stdout | version_compare(
-         _omero_web_new_version,
-         omero_web_checkupgrade_comparator))
+      (
+        not (_omero_web_new_version | regex_search('^[0-9]'))
+      ) or (
+        omero_web_symlink_st.stat.exists and
+        (omero_web_version.stdout is version_compare(
+           _omero_web_new_version,
+           omero_web_checkupgrade_comparator)
+        )
+      )
     }}"
 
 - debug:


### PR DESCRIPTION
Non-standard strings (e.g. CI job names) can no longer be compared against versions. Since this usually indicates a CI build unconditionanally upgrade.

Also fixes a deprecation warning:
[DEPRECATION WARNING]: Using tests as filters is deprecated. Instead of using
`result|version_compare` use `result is version_compare`. This feature will be
removed in version 2.9. Deprecation warnings can be disabled by setting
deprecation_warnings=False in ansible.cfg.