### PR TITLE
Don't install basedeps (py3)

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -17,6 +17,7 @@ dependencies:
   - role: ome.omego
     when: not omero_web_python3
   - role: ome.basedeps
+    when: not omero_web_python3
   - role: ome.ice
     ice_version: "{{ omero_web_ice_version }}"
     when: not omero_web_python3


### PR DESCRIPTION
Remove unnecessary `ome.basedeps` dependency.
This is quite a large dependency because it installs `redhat-lsb-core`