### PR TITLE
If omero_web_apps_top_links .attrs not set omit

### DIFF
--- a/molecule/active/molecule.yml
+++ b/molecule/active/molecule.yml
@@ -21,7 +21,7 @@ provisioner:
   inventory:
     host_vars:
       omero-web-active:
-        omero_web_release: latest
+        omero_web_release: 5.5
 scenario:
   name: active
 verifier:

--- a/molecule/active/tests/test_default.py
+++ b/molecule/active/tests/test_default.py
@@ -24,8 +24,8 @@ def test_omero_version(host):
         ver = host.check_output("%s version" % OMERO)
     m = VERSION_PATTERN.match(ver)
     assert m is not None
-    assert int(m.group(1)) >= 5
-    assert int(m.group(2)) > 3
+    # This is an old Python 2 test so it'll never be more recent than 5.5.1
+    assert m.groups() == ('5', '5', '1')
 
 
 @pytest.mark.parametrize("name", ["omero-web", "nginx"])

--- a/templates/omero-web-apps-omero.j2
+++ b/templates/omero-web-apps-omero.j2
@@ -7,7 +7,11 @@ config append -- omero.web.apps {{ item | to_json | quote }}
 
 # add top links
 {% for item in omero_web_apps_top_links %}
-config append -- omero.web.ui.top_links {{ [item.label, item.link, (item.attrs | default({}))] | to_json | quote }}
+{%   if 'attrs' in item %}
+config append -- omero.web.ui.top_links {{ [item.label, item.link, item.attrs] | to_json | quote }}
+{%   else %}
+config append -- omero.web.ui.top_links {{ [item.label, item.link] | to_json | quote }}
+{%   endif %}
 {% endfor %}
 
 # ui metadata panes


### PR DESCRIPTION
`attrs` is optional in the top-links setting. It may or may not matter whether it's `{}` vs omitted.