### PR TITLE
Use ome.python3_virtualenv role

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -25,4 +25,6 @@ dependencies:
     when: omero_web_setup_nginx
   - role: ome.omero_python_deps
     when: not omero_web_python3
+  - role: ome.python3_virtualenv
+    when: omero_web_python3
   - role: ome.selinux_utils

--- a/molecule/resources/requirements.yml
+++ b/molecule/resources/requirements.yml
@@ -5,4 +5,7 @@
 - src: ome.omero_python_deps
 - src: ome.ice
 - src: ome.nginx
+- name: ome.python3_virtualenv
+  src: >-
+    https://github.com/manics/ansible-role-python3-virtualenv/archive/11af8c8993c8f7e783d01deed9cbbf4095e9efb5.tar.gz
 - src: ome.selinux_utils

--- a/molecule/resources/requirements.yml
+++ b/molecule/resources/requirements.yml
@@ -5,7 +5,5 @@
 - src: ome.omero_python_deps
 - src: ome.ice
 - src: ome.nginx
-- name: ome.python3_virtualenv
-  src: >-
-    https://github.com/manics/ansible-role-python3-virtualenv/archive/11af8c8993c8f7e783d01deed9cbbf4095e9efb5.tar.gz
+- src: ome.python3_virtualenv
 - src: ome.selinux_utils

--- a/tasks/web-install-py3.yml
+++ b/tasks/web-install-py3.yml
@@ -6,24 +6,6 @@
 # and parse using
 # https://stackoverflow.com/questions/54025894/how-to-sort-version-numbers-in-ansible
 
-# TODO: Move to a separate role?
-- name: omero web | install python3
-  become: true
-  yum:
-    name: python36
-    state: present
-  when: ansible_os_family == 'RedHat'
-
-- name: omero web | install python3
-  become: true
-  apt:
-    name:
-      - python3.6
-      - python3.6-distutils
-      - python3.6-venv
-    state: present
-  when: ansible_os_family == 'Debian'
-
 - name: omero web | is web symlink present
   become: true
   stat:
@@ -120,7 +102,7 @@
       }}
     state: present
     virtualenv: "{{ omero_web_virtualenv_basedir }}"
-    virtualenv_command: /usr/bin/python3 -mvenv
+    virtualenv_command: /usr/local/bin/ome-python3-virtualenv.sh
   notify:
     - omero-web rewrite omero-web configuration
     - omero-web restart omero-web

--- a/tasks/web-install-py3.yml
+++ b/tasks/web-install-py3.yml
@@ -102,7 +102,7 @@
       }}
     state: present
     virtualenv: "{{ omero_web_virtualenv_basedir }}"
-    virtualenv_command: /usr/local/bin/ome-python3-virtualenv.sh
+    virtualenv_command: /usr/local/bin/ome-python3-virtualenv
   notify:
     - omero-web rewrite omero-web configuration
     - omero-web restart omero-web


### PR DESCRIPTION
Uses https://github.com/manics/ansible-role-python3-virtualenv to avoid installing python3 in multiple roles. Also takes care of some Ansible weirdness with virtualenv