### PR TITLE
For Python 2 tasks, cap setuptools_scm under 6.0.0

### DIFF
--- a/tasks/web-install-py2.yml
+++ b/tasks/web-install-py2.yml
@@ -154,7 +154,16 @@
     - omero-web rewrite omero-web configuration
     - omero-web restart omero-web
 
-- name: omero web | setup virtualenv
+- name: omero web | install setuptool_scm
+  become: true
+  pip:
+    name:
+      - setuptools_scm < 6.0.0
+    state: present
+    virtualenv: "{{ omero_web_virtualenv_basedir }}"
+    virtualenv_site_packages: true
+
+- name: omero web | install requirements
   become: true
   pip:
     requirements: >-


### PR DESCRIPTION
Fixes the failing scheduled build https://github.com/ome/ansible-role-omero-web/actions/runs/674067767

`setuptools_scm 6.0.0` dropped support for Python < 3.6 but the markers are not recognized by the default pip version installed in the virtual environment.

This raises a more fundamental the question of whether the role should keep supporting this workflow. Python 2 is EOL and the last compatible OMERO.web contain security vulnerabilities. An alternative to patching the role would be to agree on the roadmap for supporting Python 3 only.