### PR TITLE
Add optional variable allowing to delete packages from the venv

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -31,6 +31,8 @@ omero_web_setup_nginx: true
 # List of additional Python packages to be installed into virtualenv
 omero_web_python_addons: []
 
+# List of Python packages to delete from the virtual environment
+omero_web_python_delete: []
 
 ######################################################################
 # defaults from the old omero-web-apps

--- a/tasks/web-install-py3.yml
+++ b/tasks/web-install-py3.yml
@@ -120,6 +120,17 @@
     - omero-web rewrite omero-web configuration
     - omero-web restart omero-web
 
+- name: omero web | remove requirements
+  become: true
+  pip:
+    name: "{{ omero_web_python_delete }}"
+    state: absent
+    virtualenv: "{{ omero_web_virtualenv_basedir }}"
+    virtualenv_command: /usr/local/bin/ome-python3-virtualenv
+  notify:
+    - omero-web rewrite omero-web configuration
+    - omero-web restart omero-web
+
 # Remembering to set OMERODIR everywhere is prone to error
 - name: omero web | create omero web wrapper
   become: true


### PR DESCRIPTION
See https://github.com/ome/prod-playbooks/pull/332

Primarily motivated by the [Django 3.2 upgrade](https://www.openmicroscopy.org/2022/02/18/omeroweb-django-upgrade.html) as well as the new IDR gallery work. This PR tries to address the scenario where existing deployments needs to be upgraded and packages need to be removed from a virtual environment e.g. for incompatibility reasons.

`pip` does not have any built-in functionality to uninstall anything that is not part of a high-level list of requirements. A workaround is to define a new extra list of packages to uninstall and actively manage packages removal.

Proposed tag: `4.1.0`