### PR TITLE
added omero_web_system_user_manage toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ OMERO.web version and installation.
   The default is `present` which will install the latest version if web is not already installed, but will not modify an existing web.
   Use `latest` to automatically upgrade when a new version is released.
 - `omero_web_system_user`: OMERO.web system user, default `omero-web`.
+- `omero_web_system_user_manage`: Create or update the OMERO.web system user if necessary, default `True`.
 - `omero_web_system_uid`: OMERO.web system user ID (default automatic)
 
 OMERO.web configuration.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,6 +5,7 @@ omero_web_release: present
 
 # OMERO.web system user
 omero_web_system_user: omero-web
+omero_web_system_user_manage: true
 
 # OMERO.web system user ID (If not defined one is chosen automatically)
 # omero_web_system_uid:

--- a/tasks/web-install-py3.yml
+++ b/tasks/web-install-py3.yml
@@ -50,6 +50,7 @@
     state: present
     system: true
     uid: "{{ omero_web_system_uid | default(omit) }}"
+  when: omero_web_system_user_manage
 
 - name: omero web | create OMERODIR writeable
   become: true


### PR DESCRIPTION
We are managing omero system users across several instances directly through ldap. The task `omero web | create system user` can fail if the `omero_web_system_user` already exists with a different home directory. The sister `ome.omero-server` role includes a `omero_server_system_user_manage` flag to skip the user creation task. This pull requests adds a similar `omero_web_system_user_manage` flag here to possibly skip the user creation task.