### PR TITLE
Support of the session engine with Redis 

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ OMERO.web with the redis session engine
     hosts: localhost    
     roles:
     - role: ome.omero_web
+      omero_web_setup_redis_session: true
       omero_web_config_set:
         "omero.web.caches":
            "default": 

--- a/README.md
+++ b/README.md
@@ -99,6 +99,18 @@ OMERO.web with a custom configuration using `omero_web_config_set`:
             omero.web.public.user: public
             omero.web.public.password: secret-password
 
+OMERO.web with the redis session engine    
+   
+    hosts: localhost    
+    roles:
+    - role: ome.omero_web
+      omero_web_config_set:
+        "omero.web.caches":
+           "default": 
+              "BACKEND": "django_redis.cache.RedisCache"
+              "LOCATION": "redis://127.0.0.1:6379/0"
+        "omero.web.session_engine": "django.contrib.sessions.backends.cache"
+
 OMERO.web with a custom configuration using a configuration file `web-custom-config.omero`:
 
     - hosts: localhost

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -28,6 +28,9 @@ omero_web_config_set: {}
 # Install and configure Nginx
 omero_web_setup_nginx: true
 
+# Install required package to deploy redis session engine
+omero_web_setup_redis_session: false
+
 # List of additional Python packages to be installed into virtualenv
 omero_web_python_addons: []
 

--- a/tasks/web-install-py3.yml
+++ b/tasks/web-install-py3.yml
@@ -114,6 +114,17 @@
     - omero-web rewrite omero-web configuration
     - omero-web restart omero-web
 
+- name: omero web | install django_redis
+  become: true
+  pip:
+    name: django_redis
+    state: present
+    virtualenv: "{{ omero_web_virtualenv_basedir }}"
+    virtualenv_command: /usr/local/bin/ome-python3-virtualenv
+  notify:
+    - omero-web rewrite omero-web configuration
+    - omero-web restart omero-web
+
 # TODO: figure out dependencies, use omero-web version
 # Install/upgrade OMERO.web after the configuration files are updated
 # This should mean that if OMERO.web fails to start due to a configuration

--- a/tasks/web-install-py3.yml
+++ b/tasks/web-install-py3.yml
@@ -124,6 +124,7 @@
   notify:
     - omero-web rewrite omero-web configuration
     - omero-web restart omero-web
+  when: omero_web_setup_redis_session
 
 # TODO: figure out dependencies, use omero-web version
 # Install/upgrade OMERO.web after the configuration files are updated


### PR DESCRIPTION
This PR adds the support of the session engine with Redis for the Omero  web role
It includes an example of deploying the web client with the Redis session engine in the readme file.
