### PR TITLE
Become root

### DIFF
--- a/tasks/web-dependencies.yml
+++ b/tasks/web-dependencies.yml
@@ -86,6 +86,7 @@
   when: mod_file_name.stat.exists
 
 - name: omero web | delete mod file
+  become: true
   ansible.builtin.file:
     path: /tmp/django.mod
     state: absent


### PR DESCRIPTION
Fixes the issue on rocky9: 
```
TASK [ome.omero_web : omero web | delete mod file] *********************************************************************************************************************************
fatal: [2f5d1f82-2aad-433b-ab9f-98c5fe25ffa5]: FAILED! => {"changed": false, "gid": 0, "group": "root", "mode": "0644", "msg": "unlinking failed: [Errno 1] Operation not permitted: b'/tmp/django.mod' ", "owner": "root", "path": "/tmp/django.mod", "secontext": "unconfined_u:object_r:user_tmp_t:s0", "size": 1104, "state": "file", "uid": 0}
```

Also added selinux command to allow nginx to serve omero.web, based on https://github.com/openmicroscopy/management_tools/pull/1710/files#r1516332291 (thanks @pwalczysko !)
There was a comment saying "SELinux should be handled by openmicroscopy.omero-web-runtime" but omero-web-runtime: "This repository has been archived by the owner on Jan 8, 2021. It is now read-only. ", so maybe shouldn't rely on that.

