### PR TITLE
Set httpd_can_network_relay SELinux boolean

### DIFF
--- a/tasks/web-dependencies.yml
+++ b/tasks/web-dependencies.yml
@@ -9,6 +9,7 @@
   with_items:
     - httpd_read_user_content
     - httpd_enable_homedirs
+    - httpd_can_network_relay
   when: selinux_enabled
 
 # Alternatively set httpd_can_network_connect=yes to allow all ports

--- a/tasks/web-nginx.yml
+++ b/tasks/web-nginx.yml
@@ -41,5 +41,3 @@
     enabled: true
     name: nginx
     state: started
-
-# SELinux should be handled by openmicroscopy.omero-web-runtime


### PR DESCRIPTION
On modern operating systems like RHEL9/Rocky Linux 9 with SELinux enabled this was found to be a requirement to allow Nginx to serve the OMERO.web Django application

Also cleans up a comment about the archived omero-web-runtime role