### PR TITLE
WiP: Replace include with include_task

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,14 +1,24 @@
 ---
 # tasks for omero-web
--
-- include: pre_tasks.yml
 
-- include: web-dependencies.yml
+- name: Include pre-tasks.yml
+  include_tasks:
+    file: pre_tasks.yml
 
-- include: web-install-py3.yml
+- name: Include web-dependencies.yml
+  include_tasks:
+    file: web-dependencies.yml
 
-- include: web-systemd.yml
+- name: Include web-install-py3.yml
+  include_tasks:
+    file: web-install-py3.yml
+
+- name: Include web-systemd.yml
+  include_tasks:
+    file: web-systemd.yml
   when: omero_web_systemd_setup
 
-- include: web-nginx.yml
+- name: Include web-nginx.yml
+  include_tasks:
+    file: web-nginx.yml
   when: omero_web_setup_nginx


### PR DESCRIPTION
Similar to @khaledk2 PR https://github.com/ome/ansible-role-omero-server/pull/79/files.

This works for me in a playbook with python 3.12 and ansible

```
ansible --version
ansible [core 2.18.7]
  config file = None
  configured module search path = ['/Users/pwalczysko/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/pwalczysko/opt/anaconda3/envs/ansible-test/lib/python3.12/site-packages/ansible
  ansible collection location = /Users/pwalczysko/.ansible/collections:/usr/share/ansible/collections
  executable location = /Users/pwalczysko/opt/anaconda3/envs/ansible-test/bin/ansible
  python version = 3.12.11 | packaged by Anaconda, Inc. | (main, Jun  5 2025, 08:03:38) [Clang 14.0.6 ] (/Users/pwalczysko/opt/anaconda3/envs/ansible-test/bin/python3.12)
  jinja version = 3.1.6
  libyaml = True
```

Will consult with @khaledk2 the unification of syntax and usage of ``import_`` vs ``include_``