### PR TITLE
Do not force the update of the cache during package installation

### DIFF
--- a/tasks/web-dependencies.yml
+++ b/tasks/web-dependencies.yml
@@ -38,7 +38,6 @@
 - name: omero web | install checkpolicy
   become: true
   ansible.builtin.dnf:
-    update_cache: true
     name:
       - checkpolicy
       - policycoreutils
@@ -50,7 +49,6 @@
 - name: omero web | install checkpolicy for ubuntu
   become: true
   ansible.builtin.apt:
-    update_cache: true
     name:
       - checkpolicy
       - policycoreutils


### PR DESCRIPTION
See https://github.com/IDR/deployment/issues/433 and https://github.com/ome/ansible-role-omero-server/pull/81
This flag creates an unnecessary overhead for every package installation  task