### PR TITLE
Python 3.12

### DIFF
--- a/tasks/web-dependencies.yml
+++ b/tasks/web-dependencies.yml
@@ -15,6 +15,8 @@
 # Alternatively set httpd_can_network_connect=yes to allow all ports
 - name: omero web | selinux ports
   become: true
+  vars:
+    ansible_python_interpreter: "/usr/bin/python"
   seport:
     ports: "4080"
     proto: tcp


### PR DESCRIPTION
This is continuing the effort to upgrade to higher ansible and Python 3.12 similar to https://github.com/ome/ansible-role-omero-server/pull/82.

Step 1:

Some packages, such as ``libselinux-python3`` are not available on ``/usr/bin/python3.12`` but only on the default RHEL 9 python (``/usr/bin/python``)

Thus, the ``ansible_python_interpreter`` must be pointed onto ``/usr/bin/python``.

The testing was done on the ``ome-train4-ap1`` VM with the ``omero_web`` role taken from the ``master`` branch here.

