### PR TITLE
Add additional  web systemd variable 

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -113,6 +113,9 @@ omero_web_always_reset_config: true
 # DEVELOPMENT: Automatically start systemd omero-web
 omero_web_systemd_start: true
 
+# Dictionary of additional service variables
+omero_additional_web_systemd_vars: {}
+
 # Base directory for the web installation
 omero_web_basedir: "{{ omero_common_basedir }}/web"
 

--- a/molecule/resources/playbook.yml
+++ b/molecule/resources/playbook.yml
@@ -91,3 +91,7 @@
         example.string: example value
         example.boolean: true
         example.integer: 2
+      omero_additional_web_systemd_vars:
+        Restart: on-failure
+        StartLimitIntervalSec: 600
+        StartLimitBurst: 5

--- a/molecule/resources/tests/test_default.py
+++ b/molecule/resources/tests/test_default.py
@@ -38,3 +38,10 @@ def test_omero_version(host):
     assert m is not None
     assert int(m.group(1)) >= 5
     assert int(m.group(2)) > 3
+
+# test for omero_additional_web_systemd_vars new var
+def test_omero_web_service_config(host):
+    serv_cfg = host.check_output("cat /etc/systemd/system/omero-web.service")
+    assert 'StartLimitIntervalSec=600' in serv_cfg
+    assert 'StartLimitBurst=5' in serv_cfg
+    assert 'Restart=on-failure' in serv_cfg

--- a/templates/systemd-system-omero-web-service.j2
+++ b/templates/systemd-system-omero-web-service.j2
@@ -20,6 +20,9 @@ ExecStop={{ omero_web_omero_command }} web stop
 {% if omero_web_systemd_limit_nofile %}
 LimitNOFILE={{ omero_web_systemd_limit_nofile }}
 {% endif %}
+{% for name in (omero_additional_web_systemd_vars | sort) %}
+{{ name }}={{ omero_additional_web_systemd_vars[name] | quote }}
+{% endfor %}
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
This PR adds a configurable variable, i.e.  `omero_additional_web_systemd_vars`.,  to extend the service section of a service definition file (i.e. omero-web.service), giving users more flexibility.
