### PR TITLE
Fix service warnning

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -113,8 +113,11 @@ omero_web_always_reset_config: true
 # DEVELOPMENT: Automatically start systemd omero-web
 omero_web_systemd_start: true
 
-# Dictionary of additional service variables
-omero_additional_web_systemd_vars: {}
+# Dictionary of additional service, service part, variables
+omero_additional_web_systemd_service_vars: {}
+
+# Dictionary of additional service, unit part,  variables
+omero_additional_web_systemd_unit_vars: {}
 
 # Base directory for the web installation
 omero_web_basedir: "{{ omero_common_basedir }}/web"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -113,10 +113,10 @@ omero_web_always_reset_config: true
 # DEVELOPMENT: Automatically start systemd omero-web
 omero_web_systemd_start: true
 
-# Dictionary of additional service, service part, variables
+# Dictionary of additional service variables (service part)
 omero_additional_web_systemd_service_vars: {}
 
-# Dictionary of additional service, unit part,  variables
+# Dictionary of additional service variables (unit part)  
 omero_additional_web_systemd_unit_vars: {}
 
 # Base directory for the web installation

--- a/molecule/resources/playbook.yml
+++ b/molecule/resources/playbook.yml
@@ -91,7 +91,8 @@
         example.string: example value
         example.boolean: true
         example.integer: 2
-      omero_additional_web_systemd_vars:
+      omero_additional_web_systemd_service_vars:
         Restart: on-failure
+      omero_additional_web_systemd_unit_vars:
         StartLimitIntervalSec: 600
         StartLimitBurst: 5

--- a/molecule/resources/tests/test_default.py
+++ b/molecule/resources/tests/test_default.py
@@ -45,3 +45,8 @@ def test_omero_web_service_config(host):
     assert 'StartLimitIntervalSec=600' in serv_cfg
     assert 'StartLimitBurst=5' in serv_cfg
     assert 'Restart=on-failure' in serv_cfg
+
+# test for service variables validation
+def test_omero_web_service_config(host):
+    serv_ana = host.check_output("systemd-analyze verify omero-web.service")
+    assert 'Unknown key name' not in serv_ana

--- a/templates/systemd-system-omero-web-service.j2
+++ b/templates/systemd-system-omero-web-service.j2
@@ -7,7 +7,6 @@ After=network.service
 {% endfor %}
 {% for value in omero_web_systemd_requires %}Requires={{ value }}
 {% endfor %}
-{% endif %}
 {% for name in (omero_additional_web_systemd_unit_vars | sort) %}
 {{ name }}={{ omero_additional_web_systemd_unit_vars[name] | quote }}
 {% endfor %}

--- a/templates/systemd-system-omero-web-service.j2
+++ b/templates/systemd-system-omero-web-service.j2
@@ -7,6 +7,10 @@ After=network.service
 {% endfor %}
 {% for value in omero_web_systemd_requires %}Requires={{ value }}
 {% endfor %}
+{% endif %}
+{% for name in (omero_additional_web_systemd_unit_vars | sort) %}
+{{ name }}={{ omero_additional_web_systemd_unit_vars[name] | quote }}
+{% endfor %}
 
 [Service]
 User={{ omero_web_system_user }}
@@ -20,8 +24,8 @@ ExecStop={{ omero_web_omero_command }} web stop
 {% if omero_web_systemd_limit_nofile %}
 LimitNOFILE={{ omero_web_systemd_limit_nofile }}
 {% endif %}
-{% for name in (omero_additional_web_systemd_vars | sort) %}
-{{ name }}={{ omero_additional_web_systemd_vars[name] | quote }}
+{% for name in (omero_additional_web_systemd_service_vars | sort) %}
+{{ name }}={{ omero_additional_web_systemd_service_vars[name] | quote }}
 {% endfor %}
 
 [Install]


### PR DESCRIPTION
This PR fixes this issue :

https://github.com/ome/ansible-role-omero-server/pull/89#issuecomment-4489677069

It adds two vars instead of one, one to be added to the `unit `and the other to the `service `section in the service file.

In addition, it has added a test unit to validate the vars.

@pwalczysko