### PR TITLE
Fix molecule yml syntax

### DIFF
--- a/molecule/active-rockylinux9/molecule.yml
+++ b/molecule/active-rockylinux9/molecule.yml
@@ -12,7 +12,7 @@ lint: |
 platforms:
   - name: omero-web-active-rockylinux9
     image: eniocarboni/docker-rockylinux-systemd:9
-    image_version: latest
+    # image_version: latest
     command: /sbin/init
     privileged: true
     cgroupns_mode: host


### PR DESCRIPTION
Similar to https://github.com/ome/ansible-role-omero-server/pull/93 on ansible-role-omero-server repo.

The molecule 26 does not accept the ``image_version`` tag.